### PR TITLE
fix: support glob patterns in workspaces property of package.json

### DIFF
--- a/.changeset/great-lemons-hammer.md
+++ b/.changeset/great-lemons-hammer.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+post_install.js script doesn't successfuly create .svelte-kit directory in monorepositories that use glob patterns to enumerate their workspaces. Using globby allows us to support both fully enumerated workspace directories and glob patterns.

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -16,6 +16,7 @@
 		"cookie": "^0.5.0",
 		"devalue": "^4.3.1",
 		"esm-env": "^1.0.0",
+		"globby": "^13.2.2",
 		"kleur": "^4.1.5",
 		"magic-string": "^0.30.0",
 		"mime": "^3.0.0",

--- a/packages/kit/postinstall.js
+++ b/packages/kit/postinstall.js
@@ -1,8 +1,7 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { load_config } from './src/core/config/index.js';
-import { list_files } from './src/core/utils.js';
 import * as sync from './src/core/sync/sync.js';
+import { globby } from 'globby';
 
 try {
 	const cwd = process.env.INIT_CWD ?? process.cwd();
@@ -18,7 +17,7 @@ try {
 			const packages = Array.isArray(pkg.workspaces) ? pkg.workspaces : pkg.workspaces.packages;
 
 			for (const directory of packages) {
-				directories.push(...list_files(directory).map((dir) => path.resolve(cwd, dir)));
+				directories.push(...(await globby(directory, { onlyDirectories: true, absolute: true })))
 			}
 		} else {
 			directories.push(cwd);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,6 +385,9 @@ importers:
       esm-env:
         specifier: ^1.0.0
         version: 1.0.0
+      globby:
+        specifier: ^13.2.2
+        version: 13.2.2
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
@@ -3179,7 +3182,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
-    dev: true
 
   /doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -3905,6 +3907,17 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /globby@13.2.2:
+    resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      dir-glob: 3.0.1
+      fast-glob: 3.3.1
+      ignore: 5.2.4
+      merge2: 1.4.1
+      slash: 4.0.0
+    dev: false
+
   /globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
@@ -4013,7 +4026,6 @@ packages:
   /ignore@5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
-    dev: true
 
   /imagetools-core@4.0.5:
     resolution: {integrity: sha512-sNRVfUwkUcsVWNn5inTHDXWzpPRWPWbSgGkuQmlsFCWXAR2+K5R5vG5tC3Qs4LeJaMugKB8hGVm6rvZjFHQrUw==}
@@ -5000,7 +5012,6 @@ packages:
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-    dev: true
 
   /pathe@1.1.1:
     resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
@@ -5617,6 +5628,11 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
     dev: true
+
+  /slash@4.0.0:
+    resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
+    engines: {node: '>=12'}
+    dev: false
 
   /smartwrap@2.0.2:
     resolution: {integrity: sha512-vCsKNQxb7PnCNd2wY1WClWifAc2lwqsG8OaswpJkVJsvMGcnEntdTCDajZCkk93Ay1U3t/9puJmb525Rg5MZBA==}


### PR DESCRIPTION
postinstall.js script doesn't successfuly create `.svelte-kit` directory in monorepositories that use glob patterns to enumerate their workspaces. Using [globby](https://www.npmjs.com/package/globby) allows us to support both fully enumerated workspace directories and glob patterns.

For example, our monorepositories top-level package.json contains the following for its workspaces:
```json
  "workspaces": [
    "packages/*",
    "examples/*",
    "clients/*"
  ],
  ```
  
The current postinstall script looks for a literal directory called `packages/*`, which obviously doesn't exist. [NPM package.json documentation](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#workspaces) has examples of using glob patterns, and the [JSON schema](https://github.com/SchemaStore/schemastore/blob/875dabd7c046bf36d20cdcfab06544c75eab5eec/src/schemas/json/package.json#L760) for package.json says it supports glob patterns.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
#10610

- [x] This message body should clearly illustrate what problems it solves.

> - [ ] Ideally, include a test that fails without this PR but passes with it.

There are no tests for the post_install.js script. It would be easy to add a test for this specific functionality if tests already existed but writing tests for the whole script seems out of scope for this PR.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
